### PR TITLE
[CHORE] 고교생 기록 관련 api, 마이페이지 계정정보 조회 api auth 적용

### DIFF
--- a/src/constants/responseMessage.ts
+++ b/src/constants/responseMessage.ts
@@ -19,6 +19,7 @@ export default {
   DELETE_USER_SUCCESS: "유저 탈퇴 성공",
   DELETE_USER_FAIL: "유저 탈퇴 실패",
   NO_USER: "탈퇴했거나 가입하지 않은 유저입니다.",
+  NOT_EXISITING_USER: "존재하지 않는 유저입니다.",
 
   // 토큰
   CREATE_TOKEN_SUCCESS: "토큰 재발급 성공",

--- a/src/controller/activityController.ts
+++ b/src/controller/activityController.ts
@@ -101,7 +101,7 @@ const createBookActivity = async (req: Request, res: Response) => {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
   }
 
-  const userId = req.body.userId;
+  const userId = req.user.userId;
 
   if (!userId) {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
@@ -110,7 +110,8 @@ const createBookActivity = async (req: Request, res: Response) => {
   try {
     const bookActivityCreateDTO: BookActivityCreateDTO = req.body;
     const data = await activityService.createBookActivity(
-      bookActivityCreateDTO
+      bookActivityCreateDTO,
+      userId
     );
     return res
       .status(sc.OK)

--- a/src/controller/activityController.ts
+++ b/src/controller/activityController.ts
@@ -15,14 +15,15 @@ const createCreativeActivity = async (req: Request, res: Response) => {
   }
 
   const creativeActivityCreateDTO: CreativeActivityCreateDTO = req.body;
-  const userId = req.body.userId;
+  const userId = req.user.userId;
   if (!userId) {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
   }
 
   try {
     const data = await activityService.createCreativeActivity(
-      creativeActivityCreateDTO
+      creativeActivityCreateDTO,
+      userId
     );
 
     return res

--- a/src/controller/activityController.ts
+++ b/src/controller/activityController.ts
@@ -72,7 +72,7 @@ const createPrizeActivity = async (req: Request, res: Response) => {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
   }
 
-  const userId = req.body.userId;
+  const userId = req.user.userId;
 
   if (!userId) {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
@@ -81,7 +81,8 @@ const createPrizeActivity = async (req: Request, res: Response) => {
   try {
     const prizeActivityCreateDTO: PrizeActivityCreateDTO = req.body;
     const data = await activityService.createPrizeActivity(
-      prizeActivityCreateDTO
+      prizeActivityCreateDTO,
+      userId
     );
 
     return res

--- a/src/controller/activityController.ts
+++ b/src/controller/activityController.ts
@@ -42,7 +42,7 @@ const createSubjectDetailedActivity = async (req: Request, res: Response) => {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
   }
 
-  const userId = req.body.userId;
+  const userId = req.user.userId;
 
   if (!userId) {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
@@ -52,7 +52,8 @@ const createSubjectDetailedActivity = async (req: Request, res: Response) => {
     const subjectDetailedActivityCreateDTO: SubjectDetailedActivityCreateDTO =
       req.body;
     const data = await activityService.createSubjectDetailedActivity(
-      subjectDetailedActivityCreateDTO
+      subjectDetailedActivityCreateDTO,
+      userId
     );
 
     return res

--- a/src/controller/mypageController.ts
+++ b/src/controller/mypageController.ts
@@ -5,7 +5,7 @@ import { fail, success } from "../constants/response";
 import { mypageService } from "../service";
 
 const getMypage = async (req: Request, res: Response) => {
-  const userId = req.body.userId;
+  const userId = req.user.userId;
   if (!userId) {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
   }
@@ -13,10 +13,13 @@ const getMypage = async (req: Request, res: Response) => {
     const accountInfo = await mypageService.getAccountInfoByUserId(userId);
     //const allActivity = await mypageService.getActivityByUserId(+userId);
     const data = {
+      userId: accountInfo?.userId,
+      loginId: accountInfo?.loginId,
       name: accountInfo?.name,
       school: accountInfo?.school,
       grade: accountInfo?.grade,
       age: accountInfo?.age,
+      isTeen: accountInfo?.isTeen,
     };
     return res
       .status(sc.OK)

--- a/src/interfaces/activity/BookActivityCreateDTO.ts
+++ b/src/interfaces/activity/BookActivityCreateDTO.ts
@@ -1,5 +1,4 @@
 export interface BookActivityCreateDTO {
-  userId: number;
   titleAuthor: string;
   startDate: string;
   endDate: string;

--- a/src/interfaces/activity/CreativeActivityCreateDTO.ts
+++ b/src/interfaces/activity/CreativeActivityCreateDTO.ts
@@ -1,5 +1,4 @@
 export interface CreativeActivityCreateDTO {
-  userId: number;
   name: string;
   activityType: string;
   startDate: string;

--- a/src/interfaces/activity/PrizeActivityCreateDTO.ts
+++ b/src/interfaces/activity/PrizeActivityCreateDTO.ts
@@ -1,5 +1,4 @@
 export interface PrizeActivityCreateDTO {
-  userId: number;
   name: string;
   prize: string;
   date: string;

--- a/src/interfaces/activity/SubjectDetailedActivityCreateDTO.ts
+++ b/src/interfaces/activity/SubjectDetailedActivityCreateDTO.ts
@@ -1,5 +1,4 @@
 export interface SubjectDetailedActivityCreateDTO {
-  userId: number;
   subjectName: string;
   subjectContent: string;
   activitySemester: string;

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -4,6 +4,7 @@ import { rm, sc } from "../constants";
 import { fail } from "../constants/response";
 import tokenType from "../constants/tokenType";
 import jwtHandler from "../modules/jwtHandler";
+import { userService } from "../service";
 
 export default async (req: Request, res: Response, next: NextFunction) => {
   const token = req.headers.authorization?.split(" ").reverse()[0]; //? Bearer ~~ 에서 토큰만 파싱
@@ -34,6 +35,15 @@ export default async (req: Request, res: Response, next: NextFunction) => {
 
     //? 얻어낸 userId 를 Request Body 내 userId 필드에 담고, 다음 미들웨어로 넘김( next() )
     req.body.userId = userId;
+
+    const foundUser = await userService.getUserById(userId);
+    if (!foundUser) {
+      return res
+        .status(sc.BAD_REQUEST)
+        .send(fail(sc.BAD_REQUEST, rm.NOT_EXISITING_USER));
+    }
+
+    req.user = foundUser;
     next();
   } catch (error) {
     console.log(error);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,7 +6,7 @@ import { auth } from "../middlewares";
 const router: Router = Router();
 
 router.use("/auth", userRouter);
-router.use("/activity", activityRouter);
-router.use("/mypage", mypageRouter);
+router.use("/activity", auth, activityRouter);
+router.use("/mypage", auth, mypageRouter);
 
 export default router;

--- a/src/service/activityService.ts
+++ b/src/service/activityService.ts
@@ -28,11 +28,11 @@ const createCreativeActivity = async (
 
 // 과목별 세부능력 특기사항 활동 기록
 const createSubjectDetailedActivity = async (
-  subjectDetailedActivityCreateDTO: SubjectDetailedActivityCreateDTO
+  subjectDetailedActivityCreateDTO: SubjectDetailedActivityCreateDTO,
+  userId: number
 ) => {
   const data = await prisma.subject_Detailed_Ability_Activity.create({
     data: {
-      writerId: subjectDetailedActivityCreateDTO.userId,
       subjectName: subjectDetailedActivityCreateDTO.subjectName,
       subjectContent: subjectDetailedActivityCreateDTO.subjectContent,
       activitySemester: subjectDetailedActivityCreateDTO.activitySemester,
@@ -42,10 +42,11 @@ const createSubjectDetailedActivity = async (
       activityContentDetail:
         subjectDetailedActivityCreateDTO.activityContentDetail,
       subjectFurtherStudy: subjectDetailedActivityCreateDTO.subjectFurtherStudy,
+      writerId: userId,
     },
   });
   const activityId = data.activityId;
-  return { activityId };
+  return data;
 };
 
 // 수상경력 기록

--- a/src/service/activityService.ts
+++ b/src/service/activityService.ts
@@ -72,11 +72,11 @@ const createPrizeActivity = async (
 
 // 독서활동 기록
 const createBookActivity = async (
-  bookActivityCreateDTO: BookActivityCreateDTO
+  bookActivityCreateDTO: BookActivityCreateDTO,
+  userId: number
 ) => {
   const data = await prisma.book_Activity.create({
     data: {
-      writerId: bookActivityCreateDTO.userId,
       titleAuthor: bookActivityCreateDTO.titleAuthor,
       startDate: bookActivityCreateDTO.startDate,
       endDate: bookActivityCreateDTO.endDate,
@@ -88,10 +88,11 @@ const createBookActivity = async (
       quote3: bookActivityCreateDTO.quote3,
       quote4: bookActivityCreateDTO.quote4,
       quote5: bookActivityCreateDTO.quote5,
+      writerId: userId,
     },
   });
   const activityId = data.activityId;
-  return { activityId };
+  return data;
 };
 const activityService = {
   createCreativeActivity,

--- a/src/service/activityService.ts
+++ b/src/service/activityService.ts
@@ -7,11 +7,11 @@ const prisma = new PrismaClient();
 
 // 창의적 체험활동 기록
 const createCreativeActivity = async (
-  creativeActivityCreateDTO: CreativeActivityCreateDTO
+  creativeActivityCreateDTO: CreativeActivityCreateDTO,
+  userId: number
 ) => {
   const data = await prisma.creative_Activity.create({
     data: {
-      writerId: creativeActivityCreateDTO.userId,
       name: creativeActivityCreateDTO.name,
       activityType: creativeActivityCreateDTO.activityType,
       startDate: creativeActivityCreateDTO.startDate,
@@ -19,10 +19,11 @@ const createCreativeActivity = async (
       semester: creativeActivityCreateDTO.semester,
       role: creativeActivityCreateDTO.role,
       thoughts: creativeActivityCreateDTO.thoughts,
+      writerId: userId,
     },
   });
   const activityId = data.activityId;
-  return { activityId };
+  return data;
 };
 
 // 과목별 세부능력 특기사항 활동 기록
@@ -49,11 +50,11 @@ const createSubjectDetailedActivity = async (
 
 // 수상경력 기록
 const createPrizeActivity = async (
-  prizeActivityCreateDTO: PrizeActivityCreateDTO
+  prizeActivityCreateDTO: PrizeActivityCreateDTO,
+  userId: number
 ) => {
   const data = await prisma.prize_Activity.create({
     data: {
-      userId: prizeActivityCreateDTO.userId,
       name: prizeActivityCreateDTO.name,
       prize: prizeActivityCreateDTO.prize,
       date: prizeActivityCreateDTO.date,
@@ -61,10 +62,11 @@ const createPrizeActivity = async (
       prizeImage: prizeActivityCreateDTO.prizeImage,
       role: prizeActivityCreateDTO.role,
       thoughts: prizeActivityCreateDTO.thoughts,
+      writerId: userId,
     },
   });
   const activityId = data.activityId;
-  return { activityId };
+  return data;
 };
 
 // 독서활동 기록

--- a/src/service/activityService.ts
+++ b/src/service/activityService.ts
@@ -53,7 +53,7 @@ const createPrizeActivity = async (
 ) => {
   const data = await prisma.prize_Activity.create({
     data: {
-      writerId: prizeActivityCreateDTO.userId,
+      userId: prizeActivityCreateDTO.userId,
       name: prizeActivityCreateDTO.name,
       prize: prizeActivityCreateDTO.prize,
       date: prizeActivityCreateDTO.date,

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -49,9 +49,20 @@ const signIn = async (userSignInDTO: UserSignInDTO) => {
   }
 };
 
+// 유저 조회
+const getUserById = async (userId: number) => {
+  const foundUser = await prisma.user.findUnique({
+    where: {
+      userId,
+    },
+  });
+  return foundUser;
+};
+
 const userService = {
   createUser,
   signIn,
+  getUserById,
 };
 
 export default userService;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #26 


## ✨ 구현사항
<!-- 구현사항에 대한 설명을 적어주세요 -->
- api 호출 시 유저 인증을 필요로 하는 api들에 jwt accessToken을 이용한 auth를 적용하였습니다.
- api 목록
  - 고교생 창체 기록 api
  - 고교생 세특 기록 api
  - 고교생 수상 기록 api
  - 고교생 독서 기록 api
  - 마이페이지 계정정보 조회 api

